### PR TITLE
Marking root as exact match

### DIFF
--- a/docker/app-root/etc/nginx.d/rhmap.conf.tpl
+++ b/docker/app-root/etc/nginx.d/rhmap.conf.tpl
@@ -39,7 +39,7 @@ http {
             log_not_found off;
         }
 
-        location / {
+        location = / {
             root   /opt/app-root/src;
             index  index.html;
         }


### PR DESCRIPTION
To use root we need to set it as exact match. 

ping @philbrookes  