### PR TITLE
Use openshift internal dns by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Full URL to RHMAP Core platform. For example https://rhmap.corehost.net
 
 DNS server that should be used to query subdomains from BASE_HOST
 For internal networks you would need to specify your local DNS server.
+If missing default system (docker dns server) would be used.
 
 > LOG_LEVEL `optional`
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,7 @@ ADD /app-root/ /opt/app-root
 RUN chmod 777 -Rf /opt/app-root/
 
 ## Default values for required environment variables
-ENV DNS_SERVER=8.8.8.8 \
-    BASE_HOST=localhost  \
+ENV BASE_HOST=localhost  \
     PLATFORM_URL=localhost \
     BASE_PROTOCOL=http \
     LOG_LEVEL=error

--- a/docker/app-root/etc/nginx.d/rhmap.conf.tpl
+++ b/docker/app-root/etc/nginx.d/rhmap.conf.tpl
@@ -46,7 +46,7 @@ http {
 
         location = / {
             root   /opt/app-root/src;
-            index  index.html;
+            try_files /index.html /index.html;
         }
     }
 }

--- a/docker/app-root/etc/nginx.d/rhmap.conf.tpl
+++ b/docker/app-root/etc/nginx.d/rhmap.conf.tpl
@@ -17,7 +17,7 @@ http {
     server {
         include $NGINX_CONFIGURATION_PATH/proxy.conf;
         listen 8080 default_server;
-        resolver ${DNS_SERVER};
+        resolver ${DNS_SERVER} valid=30s;
         access_log /dev/stdout;
 
         ## Expose direct routes to applications running behind mbaas containers.

--- a/docker/app-root/nginx18
+++ b/docker/app-root/nginx18
@@ -1,24 +1,42 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-echo "Generating nginx configuration:
-      DNS SERVER ${DNS_SERVER}
-      BASE_HOST ${BASE_HOST}
-      BASE_PROTOCOL ${BASE_PROTOCOL}
-      PLATFORM_URL ${PLATFORM_URL}
-      LOG_LEVEL ${LOG_LEVEL}
-" 
+rhmap::start_nginx() {
+      echo "Starting nginx server"
+      exec nginx -c ${NGINX_CONFIGURATION_PATH}/rhmap.conf
+}
 
-envsubst '${DNS_SERVER}
-          ${BASE_HOST}
-          ${BASE_PROTOCOL}
-          ${PLATFORM_URL}
-          ${NGINX_CONFIGURATION_PATH}
-          ${LOG_LEVEL}' < "${NGINX_CONFIGURATION_PATH}/rhmap.conf.tpl" > "${NGINX_CONFIGURATION_PATH}/rhmap.conf"
+rhmap::setup_dns_env () {
+      if [ -z "$DNS_SERVER" ]; then
+            export DNS_SERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
+            echo "Using system dns server ${DNS_SERVER}"
+      else
+            echo "Using user defined dns server: ${DNS_SERVER}"
+      fi  
+}
 
-echo "Starting nginx server"
+rhmap::inject_env_vars() {
+      echo "Input parameters for nginx configuration:
+            DNS SERVER ${DNS_SERVER}
+            BASE_HOST ${BASE_HOST}
+            BASE_PROTOCOL ${BASE_PROTOCOL}
+            PLATFORM_URL ${PLATFORM_URL}
+            LOG_LEVEL ${LOG_LEVEL}
+      " 
+      rhmap::setup_dns_env
+
+      ## Replace only specified environment variables in files
+      envsubst '${DNS_SERVER}
+            ${BASE_HOST}
+            ${BASE_PROTOCOL}
+            ${PLATFORM_URL}
+            ${NGINX_CONFIGURATION_PATH}
+            ${LOG_LEVEL}' < "${NGINX_CONFIGURATION_PATH}/rhmap.conf.tpl" > "${NGINX_CONFIGURATION_PATH}/rhmap.conf"
+}
+
 
 source /opt/app-root/etc/generate_container_user
 
-exec nginx -c ${NGINX_CONFIGURATION_PATH}/rhmap.conf
+rhmap::inject_env_vars
+rhmap::start_nginx
 


### PR DESCRIPTION
## Motivation

Wildcard proxy should use SkyDNS by default which is dns service configured on openshift master instance. Allow to override settings for setting up custom DNS

💯  Bonus change that would invalidate query for core url every 30 seconds.  

/ @PhilipGough 